### PR TITLE
Enable non-shibbolized SSL virtual host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.1'
+
+services:
+
+  sp:
+    build: .
+    image: jhuda/sp:latest

--- a/etc-httpd/conf.d/sp.conf
+++ b/etc-httpd/conf.d/sp.conf
@@ -1,6 +1,64 @@
 ServerName archive
 AllowEncodedSlashes NoDecode
 
+<VirtualHost *:443>
+    DocumentRoot "/var/www/html"
+    AllowEncodedSlashes NoDecode
+    UseCanonicalName On
+
+    SSLEngine on
+
+    #Disable CRIME vulernability v2.4+
+    SSLCompression off
+
+    #Clean SSL Issues and enable perfect forward secrecy
+    SSLProtocol all -SSLv2 -SSLv3 -TLSv1
+    SSLHonorCipherOrder on
+    SSLCipherSuite "EECDH+ECDSA+AESGCM EECDH+aRSA+AESGCM EECDH+ECDSA+SHA384 \
+EECDH+ECDSA+SHA256 EECDH+aRSA+SHA384 EECDH+aRSA+SHA256 \
+EECDH EDH+aRSA !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"
+
+    #SSL Cert Stuff
+    SSLCertificateFile    /etc/httpd/ssl/domain.crt
+    SSLCertificateKeyFile /etc/httpd/ssl/domain.key
+    #SSLCertificateChainFile /etc/httpd/ssl/serverchain.pem
+
+    SSLProxyEngine on
+    #Bypassing certicate checking on self-signed client cert
+    SSLProxyVerify none
+    SSLProxyCheckPeerCN off
+    SSLProxyCheckPeerName off
+    SSLProxyCheckPeerExpire off
+
+    ProxyPreserveHost on
+    RequestHeader set X-Forwarded-Proto "https" env=HTTPS
+    #RequestHeader set REMOTE-USER %{REMOTE_USER}s
+
+    ProxyIOBufferSize 65536
+    ProxyPassReverse /fcrepo http://fcrepo:8080/fcrepo
+    ProxyPass /fcrepo http://fcrepo:8080/fcrepo
+
+    ProxyPassReverse /pass-user-service http://fcrepo:8080/pass-user-service
+    ProxyPass /pass-user-service http://fcrepo:8080/pass-user-service
+
+    ProxyPassReverse /app http://ember:81/app
+    ProxyPass /app http://ember:81/app
+
+    ProxyPass /es http://elasticsearch:9200/pass/_search
+    ProxyPassReverse /es http://elasticsearch:9200/pass/_search
+
+    ProxyPassReverse /schemaservice http://schemaservice:8086
+    ProxyPass /schemaservice http://schemaservice:8086
+
+    ProxyPassReverse /policyservice http://policyservice:8088
+    ProxyPass /policyservice http://policyservice:8088
+
+    ProxyPassReverse /doiservice http://doiservice:8080/pass-doi-service
+    ProxyPass /doiservice http://doiservice:8080/pass-doi-service
+
+</VirtualHost>
+
+
 <VirtualHost *:80>
 
     ServerName https://archive.local:443


### PR DESCRIPTION
This is a partial solution to jhu-sheridan-libraries/jhuda-docker#3.  
* Adds a `docker-compose`.yml file for convenience so that updated images can be built locally via `docker-compose build`
* Adds An SSL virtualHost to the apache config that proxies requests to their final destination, but does not shibbolize them

Note:  The whole apache config is copied from PASS, including services we won't use in the archive.  I just put them in the SSL config as well, keeping the status quo until things are cleaned.